### PR TITLE
Fix kanji being rendered as Chinese

### DIFF
--- a/lib/jp_text.dart
+++ b/lib/jp_text.dart
@@ -1,0 +1,29 @@
+import "package:flutter/material.dart";
+
+const _jpLocale = Locale("ja");
+
+class JpText extends Text {
+  const JpText(
+    super.data, {
+    super.key,
+    super.style,
+    super.strutStyle,
+    super.textAlign,
+    super.textDirection,
+    super.locale = _jpLocale,
+    super.softWrap,
+    super.overflow,
+    super.textScaleFactor,
+    super.maxLines,
+    super.semanticsLabel,
+    super.textWidthBasis,
+    super.textHeightBehavior,
+    super.selectionColor,
+  });
+}
+
+const jpTextStyle = TextStyle(locale: _jpLocale);
+
+extension JpTextStyle on TextStyle {
+  TextStyle jp() => copyWith(locale: _jpLocale);
+}

--- a/lib/screens/kanji_details/compound_list.dart
+++ b/lib/screens/kanji_details/compound_list.dart
@@ -1,5 +1,6 @@
 import "package:expansion_tile_card/expansion_tile_card.dart";
 import "package:flutter/material.dart";
+import "package:jsdict/jp_text.dart";
 import "package:jsdict/packages/list_extensions.dart";
 import "package:jsdict/models/models.dart";
 import "package:jsdict/packages/navigation.dart";
@@ -23,7 +24,7 @@ class CompoundList extends StatelessWidget {
                     const EdgeInsets.symmetric(vertical: 4, horizontal: 16),
                 shape:
                     compound == compounds.last ? RoundedBottomBorder(8) : null,
-                title: Text("${compound.compound} 【${compound.reading}】"),
+                title: JpText("${compound.compound} 【${compound.reading}】"),
                 subtitle: Text(compound.meanings.join(", ")),
                 trailing: const Icon(Icons.keyboard_arrow_right),
                 onTap: pushScreen(context,

--- a/lib/screens/kanji_details/kanji_details_screen.dart
+++ b/lib/screens/kanji_details/kanji_details_screen.dart
@@ -1,5 +1,6 @@
 import "package:collection/collection.dart";
 import "package:flutter/material.dart";
+import "package:jsdict/jp_text.dart";
 import "package:jsdict/packages/navigation.dart";
 import "package:jsdict/widgets/link_popup.dart";
 import "package:jsdict/models/models.dart";
@@ -45,7 +46,7 @@ class KanjiDetailsScreen extends StatelessWidget {
                       alignment: Alignment.center,
                       padding: const EdgeInsets.symmetric(vertical: 8),
                       child: Text(kanji.kanji,
-                          style: const TextStyle(fontSize: 40)),
+                          style: const TextStyle(fontSize: 40).jp()),
                     ),
                     Wrap(
                       alignment: WrapAlignment.center,
@@ -67,11 +68,11 @@ class KanjiDetailsScreen extends StatelessWidget {
                         mainAxisSize: MainAxisSize.min,
                         children: [
                           if (kanji.kunReadings.isNotEmpty)
-                            Text("Kun: ${kanji.kunReadings.join("、 ")}"),
+                            JpText("Kun: ${kanji.kunReadings.join("、 ")}"),
                           if (kanji.onReadings.isNotEmpty)
-                            Text("On: ${kanji.onReadings.join("、 ")}"),
+                            JpText("On: ${kanji.onReadings.join("、 ")}"),
                           if (kanji.radical != null)
-                            Text(
+                            JpText(
                                 "Radical: ${kanji.radical!.meanings.join(', ')} ${kanji.radical!.character}"),
                         ],
                       ),
@@ -92,8 +93,8 @@ class KanjiDetailsScreen extends StatelessWidget {
                                       child: Padding(
                                         padding: const EdgeInsets.all(8),
                                         child: Text(part,
-                                            style:
-                                                const TextStyle(fontSize: 20)),
+                                            style: const TextStyle(fontSize: 20)
+                                                .jp()),
                                       ),
                                     ),
                                   ))

--- a/lib/screens/name_details_screen.dart
+++ b/lib/screens/name_details_screen.dart
@@ -1,4 +1,5 @@
 import "package:flutter/material.dart";
+import "package:jsdict/jp_text.dart";
 import "package:jsdict/models/models.dart";
 import "package:jsdict/singletons.dart";
 import "package:jsdict/widgets/items/kanji_item.dart";
@@ -33,7 +34,7 @@ class NameDetailsScreen extends StatelessWidget {
                                     .split("\n")
                                     .reversed
                                     .join("\n"),
-                                style: const TextStyle(fontSize: 20),
+                                style: const TextStyle(fontSize: 20).jp(),
                                 textAlign: TextAlign.center),
                             const SizedBox(height: 16),
                             Text(name.meanings.join(", "),

--- a/lib/screens/search/result_page.dart
+++ b/lib/screens/search/result_page.dart
@@ -2,6 +2,7 @@ import "package:collection/collection.dart";
 import "package:flutter/gestures.dart";
 import "package:flutter/material.dart";
 import "package:infinite_scroll_pagination/infinite_scroll_pagination.dart";
+import "package:jsdict/jp_text.dart";
 import "package:jsdict/models/models.dart";
 import "package:jsdict/packages/navigation.dart";
 import "package:jsdict/providers/query_provider.dart";
@@ -195,7 +196,7 @@ class _CorrectionInfo extends StatelessWidget {
               ? RichText(
                   textAlign: TextAlign.center,
                   text: TextSpan(
-                    style: TextStyle(color: textColor, height: 1.5),
+                    style: TextStyle(color: textColor, height: 1.5).jp(),
                     children: [
                       const TextSpan(text: "Searched for "),
                       TextSpan(
@@ -247,7 +248,7 @@ class _GrammarInfo extends StatelessWidget {
               ? RichText(
                   textAlign: TextAlign.center,
                   text: TextSpan(
-                    style: TextStyle(color: textColor, height: 1.5),
+                    style: TextStyle(color: textColor, height: 1.5).jp(),
                     children: [
                       TextSpan(text: grammarInfo!.word),
                       const TextSpan(text: " could be an inflection of "),
@@ -284,7 +285,7 @@ class _ConversionInfo extends StatelessWidget {
           : EdgeInsets.zero,
       sliver: SliverToBoxAdapter(
           child: conversion != null
-              ? Text(
+              ? JpText(
                   "${conversion!.original} is ${conversion!.converted}",
                   textAlign: TextAlign.center,
                 )

--- a/lib/screens/search/search_screen.dart
+++ b/lib/screens/search/search_screen.dart
@@ -1,4 +1,5 @@
 import "package:flutter/material.dart";
+import "package:jsdict/jp_text.dart";
 import "package:jsdict/models/models.dart";
 import "package:jsdict/packages/navigation.dart";
 import "package:jsdict/providers/query_provider.dart";
@@ -31,6 +32,7 @@ class SearchScreen extends StatelessWidget {
         ),
         appBar: AppBar(
           title: TextField(
+            style: jpTextStyle,
             focusNode: searchFocusNode,
             controller: searchController,
             onSubmitted: (_) => queryProvider.updateQuery(),

--- a/lib/screens/search_options/radical_search_screen.dart
+++ b/lib/screens/search_options/radical_search_screen.dart
@@ -1,5 +1,6 @@
 import "package:collection/collection.dart";
 import "package:flutter/material.dart";
+import "package:jsdict/jp_text.dart";
 import "package:jsdict/packages/radical_search/radical_search.dart";
 import "package:jsdict/providers/query_provider.dart";
 import "package:jsdict/screens/search_options/search_options_screen.dart";
@@ -240,7 +241,7 @@ class _CustomButton extends StatelessWidget {
         ),
         child: iconData != null
             ? Icon(iconData, size: iconSize, color: iconColor)
-            : Text(text, style: textStyle),
+            : JpText(text, style: textStyle),
       ),
     );
   }

--- a/lib/screens/search_options/search_options_screen.dart
+++ b/lib/screens/search_options/search_options_screen.dart
@@ -1,4 +1,5 @@
 import "package:flutter/material.dart";
+import "package:jsdict/jp_text.dart";
 import "package:jsdict/providers/query_provider.dart";
 
 class SearchOptionsScreen extends StatelessWidget {
@@ -23,6 +24,7 @@ class SearchOptionsScreen extends StatelessWidget {
         appBar: AppBar(
           scrolledUnderElevation: 0,
           title: TextField(
+            style: jpTextStyle,
             controller: searchController,
             autofocus: false,
             decoration: InputDecoration(

--- a/lib/screens/sentence_details_screen.dart
+++ b/lib/screens/sentence_details_screen.dart
@@ -1,4 +1,5 @@
 import "package:flutter/material.dart";
+import "package:jsdict/jp_text.dart";
 import "package:jsdict/widgets/link_popup.dart";
 import "package:jsdict/models/models.dart";
 import "package:jsdict/singletons.dart";
@@ -35,7 +36,7 @@ class SentenceDetailsScreen extends StatelessWidget {
                   child: Column(
                     children: [
                       RubyText(sentence.japanese.toRubyData(),
-                          style: const TextStyle(fontSize: 18)),
+                          style: const TextStyle(fontSize: 18).jp()),
                       const SizedBox(height: 20),
                       Text(sentence.english,
                           style: const TextStyle(fontSize: 18)),

--- a/lib/screens/word_details/definition_tile.dart
+++ b/lib/screens/word_details/definition_tile.dart
@@ -1,5 +1,6 @@
 import "package:flutter/gestures.dart";
 import "package:flutter/material.dart";
+import "package:jsdict/jp_text.dart";
 import "package:jsdict/models/models.dart";
 import "package:jsdict/packages/list_extensions.dart";
 import "package:jsdict/packages/navigation.dart";
@@ -48,7 +49,7 @@ class DefinitionTile extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(definition.types.join(", ")),
-          if (definition.tags.isNotEmpty) Text(definition.tags.join(", ")),
+          if (definition.tags.isNotEmpty) JpText(definition.tags.join(", ")),
           if (definition.seeAlso.isNotEmpty)
             RichText(
                 text: TextSpan(children: [
@@ -58,7 +59,7 @@ class DefinitionTile extends StatelessWidget {
                         text: seeAlsoWord,
                         style: TextStyle(
                             color: linkColor,
-                            decoration: TextDecoration.underline),
+                            decoration: TextDecoration.underline).jp(),
                         recognizer: TapGestureRecognizer()
                           ..onTap = pushScreen(
                             context,

--- a/lib/screens/word_details/inflection_table.dart
+++ b/lib/screens/word_details/inflection_table.dart
@@ -1,4 +1,5 @@
 import "package:flutter/material.dart";
+import "package:jsdict/jp_text.dart";
 import "package:jsdict/packages/inflection/inflection.dart";
 import "package:jsdict/models/models.dart";
 import "package:ruby_text/ruby_text.dart";
@@ -86,7 +87,7 @@ class _FuriganaCell extends StatelessWidget {
   Widget build(BuildContext context) {
     return Padding(
       padding: _cellPadding,
-      child: RubyText(furigana.toRubyData()),
+      child: RubyText(furigana.toRubyData(), style: jpTextStyle),
     );
   }
 }

--- a/lib/screens/word_details/word_details_screen.dart
+++ b/lib/screens/word_details/word_details_screen.dart
@@ -1,6 +1,7 @@
 import "package:audioplayers/audioplayers.dart";
 import "package:expansion_tile_card/expansion_tile_card.dart";
 import "package:flutter/material.dart";
+import "package:jsdict/jp_text.dart";
 import "package:jsdict/packages/list_extensions.dart";
 import "package:jsdict/packages/navigation.dart";
 import "package:jsdict/widgets/link_popup.dart";
@@ -62,8 +63,8 @@ class WordDetailsScreen extends StatelessWidget {
                   padding: const EdgeInsets.symmetric(vertical: 8),
                   child: RubyText(
                     word.word.toRubyData(),
-                    style: const TextStyle(fontSize: 28),
-                    rubyStyle: const TextStyle(fontSize: 14),
+                    style: const TextStyle(fontSize: 28).jp(),
+                    rubyStyle: const TextStyle(fontSize: 14).jp(),
                   ),
                 ),
                 Wrap(
@@ -120,7 +121,7 @@ class WordDetailsScreen extends StatelessWidget {
                                 shape: collocation == word.collocations.last
                                     ? RoundedBottomBorder(8)
                                     : null,
-                                title: Text(collocation.word),
+                                title: JpText(collocation.word),
                                 subtitle: Text(collocation.meaning),
                                 trailing:
                                     const Icon(Icons.keyboard_arrow_right),
@@ -153,8 +154,9 @@ class WordDetailsScreen extends StatelessWidget {
                                           RubyTextData(otherForm.form,
                                               ruby: otherForm.reading)
                                         ],
-                                            style:
-                                                const TextStyle(fontSize: 16)),
+                                            style: const TextStyle(fontSize: 16)
+                                                .jp(),
+                                            rubyStyle: jpTextStyle),
                                       ))
                                   .toList()),
                         )
@@ -172,7 +174,7 @@ class WordDetailsScreen extends StatelessWidget {
                                 padding: const EdgeInsets.symmetric(
                                     horizontal: 16, vertical: 8),
                                 child:
-                                    Text(word.notes.deduplicate().join("\n")),
+                                    JpText(word.notes.deduplicate().join("\n")),
                               ),
                             ),
                           ],

--- a/lib/widgets/info_chips.dart
+++ b/lib/widgets/info_chips.dart
@@ -1,5 +1,6 @@
 import "package:dynamic_color/dynamic_color.dart";
 import "package:flutter/material.dart";
+import "package:jsdict/jp_text.dart";
 import "package:jsdict/providers/theme_provider.dart";
 import "package:provider/provider.dart";
 
@@ -34,10 +35,10 @@ class InfoChip extends StatelessWidget {
                         children: [
                           Icon(icon, size: 16),
                           const SizedBox(width: 2),
-                          Text(text),
+                          JpText(text),
                         ],
                       )
-                    : Text(text),
+                    : JpText(text),
               ),
             ));
       }),

--- a/lib/widgets/items/kanji_item.dart
+++ b/lib/widgets/items/kanji_item.dart
@@ -1,4 +1,5 @@
 import "package:flutter/material.dart";
+import "package:jsdict/jp_text.dart";
 import "package:jsdict/models/models.dart";
 import "package:jsdict/packages/navigation.dart";
 import "package:jsdict/screens/kanji_details/kanji_details_screen.dart";
@@ -17,16 +18,16 @@ class KanjiItem extends StatelessWidget {
         child: ListTile(
             contentPadding:
                 const EdgeInsets.symmetric(vertical: 8.0, horizontal: 22.0),
-            leading: Text(kanji.kanji, style: const TextStyle(fontSize: 35)),
+            leading: JpText(kanji.kanji, style: const TextStyle(fontSize: 35)),
             title: Text(kanji.meanings.join(", "),
                 style: const TextStyle(fontWeight: FontWeight.w500)),
             subtitle: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               mainAxisSize: MainAxisSize.min,
               children: [
-                Text("Kun: ${kanji.kunReadings.join("、 ")}"),
-                Text("On: ${kanji.onReadings.join("、 ")}"),
-                Text([
+                JpText("Kun: ${kanji.kunReadings.join("、 ")}"),
+                JpText("On: ${kanji.onReadings.join("、 ")}"),
+                JpText([
                   "${kanji.strokeCount} strokes",
                   if (kanji.jlptLevel != JLPTLevel.none)
                     "JLPT ${kanji.jlptLevel}",

--- a/lib/widgets/items/name_item.dart
+++ b/lib/widgets/items/name_item.dart
@@ -1,4 +1,5 @@
 import "package:flutter/material.dart";
+import "package:jsdict/jp_text.dart";
 import "package:jsdict/models/models.dart";
 import "package:jsdict/packages/navigation.dart";
 import "package:jsdict/screens/name_details_screen.dart";
@@ -16,7 +17,7 @@ class NameItem extends StatelessWidget {
         child: ListTile(
             contentPadding:
                 const EdgeInsets.symmetric(vertical: 8.0, horizontal: 22.0),
-            title: Text(name.reading),
+            title: JpText(name.reading),
             subtitle: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 mainAxisSize: MainAxisSize.min,

--- a/lib/widgets/items/sentence_item.dart
+++ b/lib/widgets/items/sentence_item.dart
@@ -1,4 +1,5 @@
 import "package:flutter/material.dart";
+import "package:jsdict/jp_text.dart";
 import "package:jsdict/models/models.dart";
 import "package:jsdict/packages/navigation.dart";
 import "package:jsdict/screens/sentence_details_screen.dart";
@@ -19,7 +20,7 @@ class SentenceItem extends StatelessWidget {
         child: ListTile(
             contentPadding:
                 const EdgeInsets.symmetric(vertical: 8.0, horizontal: 22.0),
-            title: RubyText(sentence.japanese.toRubyData()),
+            title: RubyText(sentence.japanese.toRubyData(), style: jpTextStyle),
             subtitle: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               mainAxisSize: MainAxisSize.min,

--- a/lib/widgets/items/word_item.dart
+++ b/lib/widgets/items/word_item.dart
@@ -1,4 +1,5 @@
 import "package:flutter/material.dart";
+import "package:jsdict/jp_text.dart";
 import "package:jsdict/models/models.dart";
 import "package:jsdict/packages/list_extensions.dart";
 import "package:jsdict/packages/navigation.dart";
@@ -23,8 +24,8 @@ class WordItem extends StatelessWidget {
               const EdgeInsets.symmetric(vertical: 8.0, horizontal: 22.0),
           title: RubyText(
             word.word.toRubyData(),
-            style: const TextStyle(fontSize: 18),
-            rubyStyle: const TextStyle(fontSize: 10),
+            style: const TextStyle(fontSize: 18).jp(),
+            rubyStyle: const TextStyle(fontSize: 10).jp(),
           ),
           subtitle: Column(
             crossAxisAlignment: CrossAxisAlignment.start,


### PR DESCRIPTION
Fixes certain characters being rendered using Chinese symbols. This is done by explicitly setting the locale property of Text widgets containing Japanese text.

Overriding the locale of the application itself was avoided to prevent text created by the framework from appearing in Japanese.

Closes #1